### PR TITLE
7.1 fix copy link functionality

### DIFF
--- a/src/pages/Documents/GenerateLinkModel.js
+++ b/src/pages/Documents/GenerateLinkModel.js
@@ -176,19 +176,27 @@ const GenerateLinkModel = ({
     });
   };
 
-  function copyTextToClipboard(text) {
-    const textarea = document.createElement("textarea");
-    textarea.value = text;
+  const unsecuredCopyToClipboard = (text) => {
+    const textArea = document.createElement("textarea");
+    textArea.value = text;
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    try {
+      document.execCommand("copy");
+    } catch (err) {
+      console.error("Unable to copy to clipboard", err);
+    }
+    document.body.removeChild(textArea);
+  };
 
-    document.body.appendChild(textarea);
-
-    textarea.select();
-    textarea.setSelectionRange(0, 99999);
-
-    navigator.clipboard.writeText(textarea.value);
-
-    document.body.removeChild(textarea);
-  }
+  const copyTextToClipboard = (text) => {
+    if (window.isSecureContext && navigator.clipboard) {
+      navigator.clipboard.writeText(text);
+    } else {
+      unsecuredCopyToClipboard(text);
+    }
+  };
 
   const submitForm = (e) => {
     return new Promise((resolve, reject) => {
@@ -220,7 +228,10 @@ const GenerateLinkModel = ({
             console.log("Link copiado com sucesso");
           } catch (err) {
             console.error("Erro ao copiar o link: ", err);
-            toast.error("Erro ao copiar o link. Por favor, copie manualmente.");
+            toast.error(
+              "Erro ao copiar o link. Por favor, copie manualmente." +
+                err.message
+            );
           }
         } else {
           toast.error(res.message);


### PR DESCRIPTION
## Change Description

In this update, changes have been made to the `copyTextToClipboard` function to enhance context security and determine the appropriate method for copying the link. Additionally, a new function called `unsecuredCopyToClipboard` has been created to utilize a deprecated method for copying in cases where copying the text would otherwise not be possible.

### Changes Made:

- Modification of the `copyTextToClipboard` function to check the security context and select the appropriate method for copying the link.
- Addition of the `unsecuredCopyToClipboard` function to utilize a deprecated method when it's not possible to copy the text otherwise.

## Tests Performed

The task was tested on both mobile and desktop devices in a local environment to ensure that the link is copied correctly on both devices.

## Pull Request Status

This pull request is ready for review and merge.

